### PR TITLE
fix bug with start of file comments

### DIFF
--- a/elementtree.lua
+++ b/elementtree.lua
@@ -540,25 +540,25 @@ local function document_load_string(value, settings)
       value_offset = end_index + 1
 
       local start_index, end_index = string.find(value, '%-%->', value_offset)
-      if start_index and end_index then
-        local comment_data_end_index <const> = start_index - 1
-        value_offset = end_index + 1
-
-        local comment_data <const> = string.sub(value, comment_data_start_index, comment_data_end_index)
-        local comment_data_trimmed <const> = assert(string.match(
-          comment_data,
-          '^%s*(.-)%s*$'
-        ))
-
-        local comment <const> = Comment(comment_data_trimmed)
-        if #stack > 0 then
-          local current_node <const> = stack[#stack]
-          current_node:insert_child(comment)
-        else
-          table.insert(root_nodes, comment)
-        end
-      else
+      if not start_index or not end_index then
         return nil, "failed to find closing comment tag at offset: " .. tostring(value_offset)
+      end
+
+      local comment_data_end_index <const> = start_index - 1
+      value_offset = end_index + 1
+
+      local comment_data <const> = string.sub(value, comment_data_start_index, comment_data_end_index)
+      local comment_data_trimmed <const> = assert(string.match(
+        comment_data,
+        '^%s*(.-)%s*$'
+      ))
+
+      local comment <const> = Comment(comment_data_trimmed)
+      if #stack > 0 then
+        local current_node <const> = stack[#stack]
+        current_node:insert_child(comment)
+      else
+        table.insert(root_nodes, comment)
       end
 
       goto next_token

--- a/elementtree.lua
+++ b/elementtree.lua
@@ -536,15 +536,15 @@ local function document_load_string(value, settings)
     local start_index, end_index = string.find(value, '^<!%-%-', value_offset)
     if start_index and end_index then
       assert(start_index == value_offset)
-      local comment_start_index <const> = end_index + 1
+      local comment_data_start_index <const> = end_index + 1
       value_offset = end_index + 1
 
       local start_index, end_index = string.find(value, '%-%->', value_offset)
       if start_index and end_index then
-        local comment_end_index <const> = start_index - 1
+        local comment_data_end_index <const> = start_index - 1
         value_offset = end_index + 1
 
-        local comment_data <const> = string.sub(value, comment_start_index, comment_end_index)
+        local comment_data <const> = string.sub(value, comment_data_start_index, comment_data_end_index)
         local comment_data_trimmed <const> = assert(string.match(
           comment_data,
           '^%s*(.-)%s*$'

--- a/elementtree.lua
+++ b/elementtree.lua
@@ -532,16 +532,18 @@ local function document_load_string(value, settings)
       goto next_token
     end
 
-    -- next element (document type, comment, tag)
-    local start_index, end_index = string.find(value, '^<[^>]*>', value_offset)
+    -- comment
+    local start_index, end_index = string.find(value, '^<!%-%-(.-)%-%->', value_offset)
+    -- print("start index: " .. start_index)
+    -- print("end index: " .. end_index)
+    -- print(string.sub(value, start_index, end_index))
     if start_index and end_index then
       assert(start_index == value_offset)
       value_offset = end_index + 1
-
-      local next_tag_data <const> = string.sub(value, start_index, end_index)
-
-      -- comment
-      local comment_data <const> = string.match(next_tag_data, '^<!%-%-(.-)%-%->$')
+      local comment_data <const> = string.match(
+          string.sub(value, start_index, end_index),
+          '^<!%-%-(.-)%-%->$'
+      )
       if comment_data then
         local comment_data_trimmed <const> = assert(string.match(
           comment_data,
@@ -555,9 +557,18 @@ local function document_load_string(value, settings)
         else
           table.insert(root_nodes, comment)
         end
-
-        goto next_token
       end
+
+      goto next_token
+    end
+
+    -- next element (document type, comment, tag)
+    local start_index, end_index = string.find(value, '^<[^>]*>', value_offset)
+    if start_index and end_index then
+      assert(start_index == value_offset)
+      value_offset = end_index + 1
+
+      local next_tag_data <const> = string.sub(value, start_index, end_index)
 
       -- XXX: special tag
       local special_data <const> = string.match(next_tag_data, '^<!(.-)>$')

--- a/tests/html/everything.html
+++ b/tests/html/everything.html
@@ -9,6 +9,7 @@
       }
     </style>
   </head>
+  <!---->
   <body>
     <h1>A Terrible Page</h1>
     <script type="text/javascript">


### PR DESCRIPTION
refactors the comment parsing code outside of the token code such that token parsing does not restrict the comment parsing code. Prior to this commit the token parsing code would hand the comment parser an invalid token, which might indicate it isn't a comment which is valid or that the token parser failed to parse the next token to contain the entire comment which would result in an invalid state for that token and the program. This change allows the comment code to read a full comment from the entire text string in the file instead of being restricted to the output of the token parser allowing for successful comment parsing.

This code still crashes at this moment as it generates multiple root nodes which the program is next expected to handle. Requesting a review from Alex Barbur on how to proceed.